### PR TITLE
Re-applied concept to SQLite databases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
 
 	<groupId>com.coalmine</groupId>
 	<artifactId>content-provider-template</artifactId>
-	<version>1.2.2</version>
+	<version>1.3.0</version>
 	<packaging>jar</packaging>
 
 	<name>content-provider-template</name>
-	<url>http://maven.apache.org</url>
+	<url>https://github.com/coalminesoftware/ContentProviderTemplate</url>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -41,7 +41,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
+				<version>3.2</version>
 				<configuration>
 					<source>1.6</source>
 					<target>1.6</target>

--- a/src/main/java/com/coalmine/contentprovider/template/BaseClientTemplate.java
+++ b/src/main/java/com/coalmine/contentprovider/template/BaseClientTemplate.java
@@ -1,0 +1,31 @@
+package com.coalmine.contentprovider.template;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import android.database.Cursor;
+
+public class BaseClientTemplate {
+	protected <RowModel> RowModel mapRow(Cursor cursor, RowMapper<RowModel> rowMapper) {
+		if(!cursor.moveToNext()) {
+			return null;
+		}
+
+		if(!cursor.isLast()) {
+			throw new IllegalArgumentException("Multiple rows returned for the given query.");
+		}
+
+		return rowMapper.mapRow(cursor, 0);
+	}
+
+	protected <RowModel> List<RowModel> mapRows(Cursor cursor, RowMapper<RowModel> rowMapper) {
+		List<RowModel> queryResults = new ArrayList<RowModel>();
+
+		int rowNumber = 0;
+		while(cursor.moveToNext()) {
+			queryResults.add(rowMapper.mapRow(cursor, rowNumber++));
+		}
+
+		return queryResults;
+	}
+}

--- a/src/main/java/com/coalmine/contentprovider/template/BaseClientTemplate.java
+++ b/src/main/java/com/coalmine/contentprovider/template/BaseClientTemplate.java
@@ -28,4 +28,11 @@ public class BaseClientTemplate {
 
 		return queryResults;
 	}
+
+	protected void processRows(Cursor cursor, RowCallbackHandler callbackHandler) {
+		int rowNumber = 0;
+		while(cursor.moveToNext()) {
+			callbackHandler.processRow(cursor, rowNumber++);
+		}
+	}
 }

--- a/src/main/java/com/coalmine/contentprovider/template/ContentProviderClientTemplate.java
+++ b/src/main/java/com/coalmine/contentprovider/template/ContentProviderClientTemplate.java
@@ -1,6 +1,5 @@
 package com.coalmine.contentprovider.template;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import android.content.ContentProvider;
@@ -16,9 +15,8 @@ import android.os.RemoteException;
  * reusable {@link RowMapper}s and {@link RowCallbackHandler}s for building business objects from
  * Cursor rows, and {@link ContentValuesMapper}s for generating {@link ContentValues} from business
  * objects. */
-public class ContentProviderClientTemplate {
+public class ContentProviderClientTemplate extends BaseClientTemplate {
 	private ContentProviderQuerier providerQuerier;
-
 
 	/** Constructs a template using a {@link ContentResolver}, to which <code>insert()</code>,
 	 * <code>query()</code> and <code>update()</code> calls are delegated.  Templates constructed
@@ -50,25 +48,15 @@ public class ContentProviderClientTemplate {
 	}
 
 	public <RowModel> RowModel query(Uri uri, String[] projection, String selectClause, String[] selectionArguments, String sortOrder, RowMapper<RowModel> rowMapper) {
-		RowModel queryResult = null;
-
 		Cursor cursor = null;
 		try {
 			cursor = providerQuerier.query(uri, projection, selectClause, selectionArguments, sortOrder);
-			if(cursor.moveToNext()) {
-				if(!cursor.isLast()) {
-					throw new IllegalArgumentException("Multiple rows returned for the given URI/query.");
-				}
-
-				queryResult = rowMapper.mapRow(cursor, 0);
-			}
+			return mapRow(cursor, rowMapper);
 		} finally {
 			if(cursor != null) {
 				cursor.close();
 			}
 		}
-
-		return queryResult;
 	}
 
 	public <RowModel> List<RowModel> queryForList(Uri uri, String[] projection, RowMapper<RowModel> rowMapper) {
@@ -76,22 +64,15 @@ public class ContentProviderClientTemplate {
 	}
 
 	public <RowModel> List<RowModel> queryForList(Uri uri, String[] projection, String selectClause, String[] selectionArguments, String sortOrder, RowMapper<RowModel> rowMapper) {
-		List<RowModel> queryResults = new ArrayList<RowModel>();
-
 		Cursor cursor = null;
 		try {
 			cursor = providerQuerier.query(uri, projection, selectClause, selectionArguments, sortOrder);
-			int rowNumber = 0;
-			while(cursor.moveToNext()) {
-				queryResults.add(rowMapper.mapRow(cursor, rowNumber++));
-			}
+			return mapRows(cursor, rowMapper);
 		} finally {
 			if(cursor != null) {
 				cursor.close();
 			}
 		}
-
-		return queryResults;
 	}
 
 	public void query(Uri uri, String[] projection, RowCallbackHandler callbackHandler) {

--- a/src/main/java/com/coalmine/contentprovider/template/ContentProviderClientTemplate.java
+++ b/src/main/java/com/coalmine/contentprovider/template/ContentProviderClientTemplate.java
@@ -10,26 +10,31 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.RemoteException;
 
-/** Providers a simpler API for developers to interact with {@link ContentProvider}s, eliminating
+/**
+ * Providers a simpler API for developers to interact with {@link ContentProvider}s, eliminating
  * much of the boilerplate code.  The design also encouraging developers to write self-contained,
  * reusable {@link RowMapper}s and {@link RowCallbackHandler}s for building business objects from
  * Cursor rows, and {@link ContentValuesMapper}s for generating {@link ContentValues} from business
- * objects. */
+ * objects.
+ */
 public class ContentProviderClientTemplate extends BaseClientTemplate {
 	private ContentProviderQuerier providerQuerier;
 
-	/** Constructs a template using a {@link ContentResolver}, to which <code>insert()</code>,
+	/**
+	 * Constructs a template using a {@link ContentResolver}, to which <code>insert()</code>,
 	 * <code>query()</code> and <code>update()</code> calls are delegated.  Templates constructed
 	 * in this fashion will incur the same performance penalty that developers can expect from
 	 * calling those methods themselves on a <code>ContentResolver</code>, compared to acquiring a
 	 * {@link ContentProviderClient} from a resolver and calling the client's corresponding methods
 	 * instead.  However, templates constructed with a resolver have the advantage of not requiring
-	 * any cleanup and not being limited to interacting with a single provider. */
+	 * any cleanup and not being limited to interacting with a single provider.
+	 */
 	public ContentProviderClientTemplate(ContentResolver contentResolver) {
 		providerQuerier = new ContentResolverQuerier(contentResolver);
 	}
 
-	/** Constructs a template using a {@link ContentProviderClient}, to which <code>insert()</code>,
+	/**
+	 * Constructs a template using a {@link ContentProviderClient}, to which <code>insert()</code>,
 	 * <code>query()</code> and <code>update()</code> calls are delegated.  Because the use of a
 	 * client avoids repeated {@link ContentProvider} lookups  and permission checks, developers
 	 * can expect to see better performance when constructing a template in this fashion.
@@ -38,7 +43,8 @@ public class ContentProviderClientTemplate extends BaseClientTemplate {
 	 * URI's handled by the provider for which the client was acquired. Clients also need to be
 	 * released when no longer needed, by calling {@link ContentProviderClient#release()}.  For
 	 * convenience, users can also call {@link #releaseClient()} on a ContentProviderClientTemplate
-	 * constructed with a ContentProviderClient. */
+	 * constructed with a ContentProviderClient.
+	 */
 	public ContentProviderClientTemplate(ContentProviderClient providerClient) {
 		providerQuerier = new ContentProviderClientQuerier(providerClient);
 	}
@@ -82,11 +88,8 @@ public class ContentProviderClientTemplate extends BaseClientTemplate {
 	public void query(Uri uri, String[] projection, String selectClause, String[] selectionArguments, String sortOrder, RowCallbackHandler callbackHandler) {
 		Cursor cursor = null;
 		try {
-			int rowNumber = 0;
 			cursor = providerQuerier.query(uri, projection, selectClause, selectionArguments, sortOrder);
-			while(cursor.moveToNext()) {
-				callbackHandler.processRow(cursor, rowNumber++);
-			}
+			processRows(cursor, callbackHandler);
 		} finally {
 			if(cursor != null) {
 				cursor.close();
@@ -121,6 +124,15 @@ public class ContentProviderClientTemplate extends BaseClientTemplate {
 		return update(uri, rowObject, mapper, null, null);
 	}
 
+	/**
+	 * Deletes the record(s) for the given URI.
+	 * 
+	 * @return The number of rows affected by the update.
+	 */
+	public int delete(Uri uri, String whereClause, String[] selectionArguments) {
+		return providerQuerier.delete(uri, whereClause, selectionArguments);
+	}
+
 	/** For templates that were constructed with a provider client, this convenience method
 	 * releases the client once it is no longer needed, by calling
 	 * {@link ContentProviderClient#release()}.
@@ -141,6 +153,7 @@ public class ContentProviderClientTemplate extends BaseClientTemplate {
 		Uri insert(Uri uri, ContentValues contentValues);
 		Cursor query(Uri uri, String[] projection, String selectClause, String[] selectionArguments, String sortOrder);
 		int update(Uri uri, ContentValues contentValues, String whereClause, String[] selectionArguments);
+		int delete(Uri uri, String whereClause, String[] selectionArguments);
 	}
 
 	private static class ContentResolverQuerier implements ContentProviderQuerier {
@@ -154,16 +167,24 @@ public class ContentProviderClientTemplate extends BaseClientTemplate {
 			this.contentResolver = contentResolver;
 		}
 
+		@Override
 		public Uri insert(Uri uri, ContentValues contentValues) {
 			return contentResolver.insert(uri, contentValues);
 		}
 
+		@Override
 		public Cursor query(Uri uri, String[] projection, String selectClause, String[] selectionArguments, String sortOrder) {
 			return contentResolver.query(uri, projection, selectClause, selectionArguments, sortOrder);
 		}
 
+		@Override
 		public int update(Uri uri, ContentValues contentValues, String whereClause, String[] selectionArguments) {
 			return contentResolver.update(uri, contentValues, whereClause, selectionArguments);
+		}
+
+		@Override
+		public int delete(Uri uri, String whereClause, String[] selectionArguments) {
+			return contentResolver.delete(uri, whereClause, selectionArguments);
 		}
 	}
 
@@ -178,27 +199,39 @@ public class ContentProviderClientTemplate extends BaseClientTemplate {
 			this.providerClient = providerClient;
 		}
 
+		@Override
 		public Uri insert(Uri uri, ContentValues contentValues) {
 			try {
 				return providerClient.insert(uri, contentValues);
 			} catch (RemoteException e) {
-				throw new RuntimeException("ContentProviderClient could not insert values.", e);
+				throw new RuntimeException("Underying ContentProviderClient could not insert values.", e);
 			}
 		}
 
+		@Override
 		public Cursor query(Uri uri, String[] projection, String selectClause, String[] selectionArguments, String sortOrder) {
 			try {
 				return providerClient.query(uri, projection, selectClause, selectionArguments, sortOrder);
 			} catch (RemoteException e) {
-				throw new RuntimeException("ContentProviderClient could not be queried.", e);
+				throw new RuntimeException("Underying ContentProviderClient could not be queried.", e);
 			}
 		}
 
+		@Override
 		public int update(Uri uri, ContentValues contentValues, String whereClause, String[] selectionArguments) {
 			try {
 				return providerClient.update(uri, contentValues, whereClause, selectionArguments);
 			} catch (RemoteException e) {
-				throw new RuntimeException("ContentProviderClient could not update values.", e);
+				throw new RuntimeException("Underying ContentProviderClient could not update values.", e);
+			}
+		}
+
+		@Override
+		public int delete(Uri uri, String whereClause, String[] selectionArguments) {
+			try {
+				return providerClient.delete(uri, whereClause, selectionArguments);
+			} catch (RemoteException e) {
+				throw new RuntimeException("Underying ContentProviderClient could not delete the record.", e);
 			}
 		}
 	}

--- a/src/main/java/com/coalmine/contentprovider/template/SQLiteDatabaseClientTemplate.java
+++ b/src/main/java/com/coalmine/contentprovider/template/SQLiteDatabaseClientTemplate.java
@@ -1,0 +1,58 @@
+package com.coalmine.contentprovider.template;
+
+import java.util.List;
+
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+import android.os.CancellationSignal;
+
+public class SQLiteDatabaseClientTemplate extends BaseClientTemplate {
+	private DatabaseRetriever databaseRetriever;
+
+	public SQLiteDatabaseClientTemplate(DatabaseRetriever databaseRetriever) {
+		this.databaseRetriever = databaseRetriever;
+	}
+
+	public SQLiteDatabaseClientTemplate(SQLiteOpenHelper openHelper) {
+		databaseRetriever = new SQLiteOpenHelperDatabaseRetriever(openHelper);
+	}
+
+	public <RowModel> List<RowModel> queryForList(boolean distinct, String table, String[] columns, String selection, String[] selectionArgs, String groupBy, String having, String orderBy, String limit, CancellationSignal cancellationSignal, RowMapper<RowModel> rowMapper) {
+		Cursor cursor = null;
+		try {
+			cursor = databaseRetriever.getReadableDatabase().query(distinct, table, columns, selection, selectionArgs, groupBy, having, orderBy, limit, cancellationSignal);
+			return mapRows(cursor, rowMapper);
+		} finally {
+			if(cursor != null) {
+				cursor.close();
+			}
+		}
+	}
+
+
+	public interface DatabaseRetriever {
+		SQLiteDatabase getReadableDatabase();
+		SQLiteDatabase getWritableDatabase();
+	}
+
+	private static class SQLiteOpenHelperDatabaseRetriever implements DatabaseRetriever {
+		private SQLiteOpenHelper openHelper;
+
+		public SQLiteOpenHelperDatabaseRetriever(SQLiteOpenHelper openHelper) {
+			this.openHelper = openHelper;
+		}
+
+		@Override
+		public SQLiteDatabase getReadableDatabase() {
+			return openHelper.getReadableDatabase();
+		}
+
+		@Override
+		public SQLiteDatabase getWritableDatabase() {
+			return openHelper.getWritableDatabase();
+		}
+	}
+}
+
+

--- a/src/main/java/com/coalmine/contentprovider/template/SQLiteDatabaseClientTemplate.java
+++ b/src/main/java/com/coalmine/contentprovider/template/SQLiteDatabaseClientTemplate.java
@@ -10,18 +10,46 @@ import android.os.CancellationSignal;
 public class SQLiteDatabaseClientTemplate extends BaseClientTemplate {
 	private DatabaseRetriever databaseRetriever;
 
+	/**
+	 * Constructs a SQLiteDatabaseClientTemplate that operates on the database provided by the given
+	 * {@link SQLiteOpenHelper}.  For projects that do not manage their databases with a SQLiteOpenHelper, please see
+	 * {@link #SQLiteDatabaseClientTemplate(DatabaseRetriever)}.
+	 */
+	public SQLiteDatabaseClientTemplate(SQLiteOpenHelper openHelper) {
+		this(new SQLiteOpenHelperDatabaseRetriever(openHelper));
+	}
+
+	/**
+	 * Constructs a SQLiteDatabaseClientTemplate that operates on the database provided by the given
+	 * {@link DatabaseRetriever}.  For projects that use {@link SQLiteOpenHelper}, please see
+	 * {@link #SQLiteDatabaseClientTemplate(SQLiteOpenHelper)}.
+	 */
 	public SQLiteDatabaseClientTemplate(DatabaseRetriever databaseRetriever) {
 		this.databaseRetriever = databaseRetriever;
 	}
 
-	public SQLiteDatabaseClientTemplate(SQLiteOpenHelper openHelper) {
-		databaseRetriever = new SQLiteOpenHelperDatabaseRetriever(openHelper);
+	public <RowModel> List<RowModel> queryForList(boolean distinct, String table, String[] columns,
+			String selection, String[] selectionArgs,
+			String groupBy, String having, String orderBy, String limit,
+			RowMapper<RowModel> rowMapper) {
+		return queryForList(distinct, table, columns,
+				selection, selectionArgs,
+				groupBy, having, orderBy, limit,
+				null, rowMapper);
 	}
 
-	public <RowModel> List<RowModel> queryForList(boolean distinct, String table, String[] columns, String selection, String[] selectionArgs, String groupBy, String having, String orderBy, String limit, CancellationSignal cancellationSignal, RowMapper<RowModel> rowMapper) {
+	public <RowModel> List<RowModel> queryForList(boolean distinct, String table, String[] columns,
+			String selection, String[] selectionArgs,
+			String groupBy, String having, String orderBy, String limit,
+			CancellationSignal cancellationSignal,
+			RowMapper<RowModel> rowMapper) {
 		Cursor cursor = null;
 		try {
-			cursor = databaseRetriever.getReadableDatabase().query(distinct, table, columns, selection, selectionArgs, groupBy, having, orderBy, limit, cancellationSignal);
+			cursor = databaseRetriever.getReadableDatabase().query(distinct, table, columns,
+					selection, selectionArgs,
+					groupBy, having, orderBy, limit,
+					cancellationSignal);
+
 			return mapRows(cursor, rowMapper);
 		} finally {
 			if(cursor != null) {
@@ -30,6 +58,126 @@ public class SQLiteDatabaseClientTemplate extends BaseClientTemplate {
 		}
 	}
 
+	public <RowModel> RowModel query(boolean distinct, String table, String[] columns,
+			String selection, String[] selectionArgs,
+			String groupBy,String having, String orderBy, String limit,
+			RowMapper<RowModel> rowMapper) {
+		return query(distinct, table, columns,
+				selection, selectionArgs,
+				groupBy, having, orderBy, limit,
+				null, rowMapper);
+	}
+
+	public <RowModel> RowModel query(boolean distinct, String table, String[] columns,
+			String selection, String[] selectionArgs,
+			String groupBy, String having, String orderBy, String limit,
+			CancellationSignal cancellationSignal,
+			RowMapper<RowModel> rowMapper) {
+		Cursor cursor = null;
+		try {
+			cursor = databaseRetriever.getReadableDatabase().query(distinct, table, columns,
+					selection, selectionArgs,
+					groupBy, having, orderBy, limit,
+					cancellationSignal);
+
+			return mapRow(cursor, rowMapper);
+		} finally {
+			if(cursor != null) {
+				cursor.close();
+			}
+		}
+	}
+
+	public void query(boolean distinct, String table, String[] columns,
+			String selection, String[] selectionArgs,
+			String groupBy, String having, String orderBy, String limit,
+			RowCallbackHandler callbackHandler) {
+		query(distinct, table, columns,
+				selection, selectionArgs,
+				groupBy, having, orderBy, limit,
+				null, callbackHandler);
+	}
+
+	public void query(boolean distinct, String table, String[] columns,
+			String selection, String[] selectionArgs,
+			String groupBy, String having, String orderBy, String limit,
+			CancellationSignal cancellationSignal,
+			RowCallbackHandler callbackHandler) {
+		Cursor cursor = null;
+		try {
+			cursor = databaseRetriever.getReadableDatabase().query(distinct, table, columns,
+					selection, selectionArgs,
+					groupBy, having, orderBy, limit,
+					cancellationSignal);
+
+			processRows(cursor, callbackHandler);
+		} finally {
+			if(cursor != null) {
+				cursor.close();
+			}
+		}
+	}
+
+	public <RowModel> long insert(String table, RowModel rowObject, ContentValuesMapper<RowModel> mapper) {
+		return databaseRetriever.getWritableDatabase().insertOrThrow(
+				table,
+				null,
+				mapper.mapContentValues(rowObject));
+	}
+
+	public <RowModel> long insert(String table, RowModel rowObject, ContentValuesMapper<RowModel> mapper,
+			ConflictAlgorithm conflictAlgorithm) {
+		return databaseRetriever.getWritableDatabase().insertWithOnConflict(
+				table,
+				null,
+				mapper.mapContentValues(rowObject),
+				conflictAlgorithm.getConstant());
+	}
+
+	public <RowModel> int update(String table, RowModel rowObject, ContentValuesMapper<RowModel> mapper,
+			String whereClause, String[] selectionArguments) {
+		return databaseRetriever.getWritableDatabase().update(
+				table,
+				mapper.mapContentValues(rowObject),
+				whereClause,
+				selectionArguments);
+	}
+
+	public <RowModel> int update(String table, RowModel rowObject, ContentValuesMapper<RowModel> mapper,
+			String whereClause, String[] selectionArguments, ConflictAlgorithm conflictAlgorithm) {
+		return databaseRetriever.getWritableDatabase().updateWithOnConflict(
+				table,
+				mapper.mapContentValues(rowObject),
+				whereClause,
+				selectionArguments,
+				conflictAlgorithm.getConstant());
+	}
+
+	public int delete(String table, String whereClause, String[] selectionArguments) {
+		return databaseRetriever.getWritableDatabase().delete(
+				table,
+				whereClause,
+				selectionArguments);
+	}
+
+	public enum ConflictAlgorithm {
+		ABORT(SQLiteDatabase.CONFLICT_ABORT),
+		FAIL(SQLiteDatabase.CONFLICT_FAIL),
+		IGNORE(SQLiteDatabase.CONFLICT_IGNORE),
+		NONE(SQLiteDatabase.CONFLICT_NONE),
+		REPLACE(SQLiteDatabase.CONFLICT_REPLACE),
+		ROLLBACK(SQLiteDatabase.CONFLICT_ROLLBACK);
+
+		private final int constant;
+
+		private ConflictAlgorithm(int constant) {
+			this.constant = constant;
+		}
+
+		public int getConstant() {
+			return constant;
+		}
+	}
 
 	public interface DatabaseRetriever {
 		SQLiteDatabase getReadableDatabase();


### PR DESCRIPTION
This PR adds a SQLiteDatabaseClientTemplate class with operations similar to those of ContentProviderClientTemplate.  Common code was pulled into a new BaseClientTemplate class that SQLiteDatabaseClientTemplate and ContentProviderClientTemplate both implement now.
